### PR TITLE
update of a script to test the start analysis button functionality

### DIFF
--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -16,6 +16,9 @@ class FlaskJSTest(unittest.TestCase):
         try:
             output_element = wait.until(EC.visibility_of_element_located((By.ID, 'output-element')))
             self.assertEqual(output_element.text, 'START ANALYSIS')
+            button_element = self.driver.find_element(By.ID, 'mybutton')
+            button_element.click()
+            wait.until(EC.url_to_be('http://localhost:5000/test.html'))
             
         except TimeoutException:
             print("Timeout occurred while waiting for the element to be visible.")


### PR DESCRIPTION
We updated the test script so that once it is launched it displays the result page and once the start analysis button is clicked it sends us to the analysis page where we have the different graphs plotted based on the scraped data